### PR TITLE
use .zarr or .fds extension depending on whether stack is set in hci

### DIFF
--- a/pfb/parser/hci.yaml
+++ b/pfb/parser/hci.yaml
@@ -244,7 +244,7 @@ inputs:
 
 outputs:
   dir-out:
-    implicit: '{current.output-filename}_{current.product}.fds'
+    implicit: ='{current.output-filename}_{current.product}' + IF(current.stack, '.zarr', '.fds')
     dtype: Directory
     must_exist: true
     mkdir: false


### PR DESCRIPTION
zarr stores don't technically need to end with .zarr but it's more consistent with the rest of breifast to name them as such so we have a conditional output which ends with .zarr if stacked and with .fds if not