### PR TITLE
ci: fix CI by caching measures data under a constant key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,16 +125,15 @@ jobs:
           restore-keys: numba-cache-${{ matrix.python-version }}-
           path: ${{ env.NUMBA_CACHE_DIR }}
 
-      - name: Fingerprint the measures data
-        if: env.SKIP_CHECKS != 'true'
-        run: curl -sSI https://www.astron.nl/iers/WSRT_Measures.ztar | grep -iE 'last-modified|etag' > measures_dir.txt
-
+      # Bump the version suffix to refresh the measures data. The key is a
+      # constant so no third-party request is made on a cache hit -- the
+      # previous etag fingerprint contacted astron.nl on every matrix leg.
       - name: Load cached CASA Measures Data
         if: env.SKIP_CHECKS != 'true'
         id: load-cached-casa-measures
         uses: actions/cache@v6
         with:
-          key: casa-measures-${{ hashFiles('measures_dir.txt')}}
+          key: casa-measures-v1
           path: |
             ~/measures
             ~/.casarc
@@ -142,18 +141,21 @@ jobs:
       - name: Download and install CASA Measures Data
         if: env.SKIP_CHECKS != 'true' && steps.load-cached-casa-measures.outputs.cache-hit != 'true'
         run: |
+          set -euo pipefail
           mkdir -p ~/measures
-          set -e
           for i in {1..3}; do
-            if curl -L https://www.astron.nl/iers/WSRT_Measures.ztar --output WSRT_Measures.ztar; then
+            if curl -sS --disable-epsv --max-time 300 \
+                 ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+                 --output WSRT_Measures.ztar; then
               break
             elif [ $i -eq 3 ]; then
-              echo "Download failed after 3 attempts."; exit 1
+              echo "::error::Could not fetch WSRT_Measures.ztar from ftp.astron.nl after 3 attempts."
+              exit 1
             else
-              echo "Retrying download..."; sleep 5
+              echo "Retrying download ($i/3)..."; sleep 5
             fi
           done
-          tar xvzf WSRT_Measures.ztar -C ~/measures
+          tar xzf WSRT_Measures.ztar -C ~/measures
           echo "measures.directory: ~/measures" > ~/.casarc
 
       - name: Install pfb-imaging

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,14 +84,14 @@ jobs:
           restore-keys: numba-cache-${{ matrix.python-version }}-
           path: ${{ env.NUMBA_CACHE_DIR }}
 
-      - name: Fingerprint the measures data
-        run: curl -sSI https://www.astron.nl/iers/WSRT_Measures.ztar | grep -iE 'last-modified|etag' > measures_dir.txt
-
+      # Bump the version suffix to refresh the measures data. The key is a
+      # constant so no third-party request is made on a cache hit -- the
+      # previous etag fingerprint contacted astron.nl on every matrix leg.
       - name: Load cached CASA Measures Data
         id: load-cached-casa-measures
         uses: actions/cache@v6
         with:
-          key: casa-measures-${{ hashFiles('measures_dir.txt')}}
+          key: casa-measures-v1
           path: |
             ~/measures
             ~/.casarc
@@ -99,18 +99,21 @@ jobs:
       - name: Download and install CASA Measures Data
         if: steps.load-cached-casa-measures.outputs.cache-hit != 'true'
         run: |
+          set -euo pipefail
           mkdir -p ~/measures
-          set -e
           for i in {1..3}; do
-            if curl -L https://www.astron.nl/iers/WSRT_Measures.ztar --output WSRT_Measures.ztar; then
+            if curl -sS --disable-epsv --max-time 300 \
+                 ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar \
+                 --output WSRT_Measures.ztar; then
               break
             elif [ $i -eq 3 ]; then
-              echo "Download failed after 3 attempts."; exit 1
+              echo "::error::Could not fetch WSRT_Measures.ztar from ftp.astron.nl after 3 attempts."
+              exit 1
             else
-              echo "Retrying download..."; sleep 5
+              echo "Retrying download ($i/3)..."; sleep 5
             fi
           done
-          tar xvzf WSRT_Measures.ztar -C ~/measures
+          tar xzf WSRT_Measures.ztar -C ~/measures
           echo "measures.directory: ~/measures" > ~/.casarc
 
       - name: Install pfb-imaging


### PR DESCRIPTION
Fixes the CI failure currently affecting `main` and every open PR.

## Cause

ASTRON removed `https://www.astron.nl/iers/`. Every request to that path returns a 404 HTML
page — verified against curl UA and a Chrome UA, HEAD and GET, HTTP/2 and HTTP/1.1, with and
without redirects, forced IPv4 and IPv6. The parent directory 404s too, which is the tell: the
path is gone, not gated by a WAF or a runner-IP rule.

The *Fingerprint the measures data* step grepped that response for `last-modified|etag`,
matched nothing, and exited 1 — which fails the step under the shell's `-e`. The exit code in
the log was grep's, not curl's, so no error message ever appeared.

`main`'s CI last passed on 2026-07-28, so the mirror died within the week. Worth knowing: run
interactively the command is completely silent in both success and failure (`-sS` suppresses
progress, `-I`'s output is redirected into the file, and grep prints nothing when it doesn't
match), so a local run looks like it works while leaving a 0-byte `measures_dir.txt` and
`$? == 1`.

## Changes

**The cache key is now a constant (`casa-measures-v1`).** The old key was
`hashFiles('measures_dir.txt')`, which meant contacting a third-party server on *every matrix
leg of every job* just to compute a cache key. Worse, the tarball is regenerated daily at
18:00 UTC, so that key rotated daily — a 20 MB re-download per leg per day even when the
mirror was healthy. Refreshing the data is now a deliberate act: bump the suffix.

**The download uses `ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar`.** That is the
only live transport left; `ftp.astron.nl` serves nothing on 443, and no HTTPS mirror of this
data exists any more. FTP was previously abandoned here because it was flaky on runners — with
a constant cache key it is now reached only on a genuine cache miss instead of on every job,
so the flaky path is off the hot path and the existing 3× retry covers it.

**Failure is loud.** `::error::` naming the mirror rather than a bare `exit 1`, plus
`set -euo pipefail` so a broken pipe can't masquerade as success. This is what cost the most
time to diagnose.

## Rejected: pinning a dated snapshot

`ftp://ftp.astron.nl/outgoing/Measures/` holds dated immutable snapshots
(`WSRT_Measures_20260803-160001.ztar`), which look like the obvious thing to pin. They are a
**~90-day rolling window** — the directory currently spans `20260506` to `20260803`, 76 files.
A dated pin would expire and re-break CI on the next cache miss, in the same quiet way. The
2017 snapshot that Homebrew's `casacore-data` formula pins has already been pruned; that
formula is broken.

## Verification

The step's `run` block was extracted verbatim from the YAML and executed against a throwaway
`HOME`: exit 0, tarball extracts to `ephemerides/` + `geodetic/`, `~/.casarc` written. Then
python-casacore was pointed at the result — `dm.observatory('meerkat')` resolves and a
J2000→AZEL conversion succeeds, which exercises the IERS/geodetic tables that
`utils/astrometry.py` needs.

Both workflows parse, and no reference to the dead URL or `measures_dir.txt` remains.

## Note

Cache eviction is the one residual exposure: `actions/cache` drops entries unused for 7 days,
so a quiet week means the next run refetches over FTP. That is the accepted trade-off for not
hosting a mirror — if FTP proves flaky again, the next step is mirroring one snapshot as a
release asset and fetching it over HTTPS from GitHub's CDN.
